### PR TITLE
Add tests, upgrade moviepy v2, fix bugs, apply code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-src/__pycache__/
 .ipynb_checkpoints/
 .python-version
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ src/__pycache__/
 .python-version
 .vscode/
 data/
+**/__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Scripts in this repo can take a video file and extract the audio from the file to an mp3. The mp3 file can be normalized so the volume of the file is consistant. Ex: You have a handful of videos and extract the audio, they can all be normalized so the louder audio is less loud, and the quieter audio is less quiet. The mp3 files can also be tagged with the album, artist, and title so programs playing the files can use the tags to sort the files correctly.
 
 ## Prerequisites
-You will need to have `ffmepg` installed on your computer. Setup uses uv, so please install that as well.
+You will need to have `ffmpeg` installed on your computer. Setup uses uv, so please install that as well.
 
 ## Installation
 1. Clone this repo
@@ -39,13 +39,13 @@ mp3 files can be normalized, which can be useful if the video file is too loud o
 
 #### Individual file
 ```bash
-uv run .\src\audio_normalizer.py --audio_path ".\some-directory\audio_file.mp3" --dFBS -20
+uv run .\src\audio_normalizer.py --audio_path ".\some-directory\audio_file.mp3" --dBFS -20
 ```
 The resulting mp3 file will be in the `.\data\normalized_audio` directory in the repo directory.
 
 #### Multiple files in a directory
 ```bash
-uv run .\src\normalize_audios_from_dir.py --dir ".\some-directory-with-audio-files-in-it" --dFBS -20
+uv run .\src\normalize_audios_from_dir.py --dir ".\some-directory-with-audio-files-in-it" --dBFS -20
 ```
 The resulting mp3 file will be in the `.\data\normalized_audio` directory in the repo directory.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "audio-extractor"
 version = "0.1.0"
-description = "Add your description here"
+description = "Extract, normalize, and tag audio from video files"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "audioop-lts>=0.2.2",
     "eyed3>=0.9.8",
-    "moviepy==1.0.3",
+    "moviepy>=2.0.0",
     "pydub>=0.25.1",
 ]
 
@@ -15,5 +15,10 @@ dependencies = [
 dev = [
     "pyright>=1.1.404",
     "pytest>=8.4.1",
+    "pytest-mock>=3.14.0",
     "ruff>=0.12.10",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/audio_extractor.py
+++ b/src/audio_extractor.py
@@ -50,12 +50,12 @@ class AudioExtractor(ProcessClass):
         """
         clip = self.get_clip()
         try:
-            os.makedirs(self.audio_dir, exist_ok=True)
-            print(f"\nExtracting audio for {self.audio_name}...\n")
             if clip.audio is None:
                 raise ValueError(
                     f"Video file {self.vid_path!r} has no audio track."
                 )
+            os.makedirs(self.audio_dir, exist_ok=True)
+            print(f"\nExtracting audio for {self.audio_name}...\n")
             clip.audio.write_audiofile(self.audio_dir / f"{self.audio_name}.mp3")
             print("\nFinished extracting audio!\n")
         finally:

--- a/src/audio_extractor.py
+++ b/src/audio_extractor.py
@@ -1,9 +1,10 @@
 import os
 import argparse
-import moviepy.editor as mp
+from moviepy import VideoFileClip
 
 from utils import get_file_strings
 from process_class import ProcessClass
+from constants import EXTRACTED_DIR
 
 
 class AudioExtractor(ProcessClass):
@@ -30,15 +31,15 @@ class AudioExtractor(ProcessClass):
             self.audio_name, _ = get_file_strings(self.vid_path)
         else:
             self.audio_name = audio_name
-        self.audio_dir = "./data/extracted_audio"
+        self.audio_dir = str(EXTRACTED_DIR)
 
-    def get_clip(self) -> mp.VideoFileClip:
+    def get_clip(self) -> VideoFileClip:
         """Returns the clip of a video file.
 
         Returns:
-            mp.VideoFileClip: Video file clip object.
+            VideoFileClip: Video file clip object.
         """
-        return mp.VideoFileClip(self.vid_path)
+        return VideoFileClip(self.vid_path)
 
     def process_file(self):
         """Extracts audio of a single file as an mp3 into the audio path folder.
@@ -49,10 +50,13 @@ class AudioExtractor(ProcessClass):
                         is the same as the video name. Defaults to None.
         """
         clip = self.get_clip()
-        os.makedirs(self.audio_dir, exist_ok=True)
-        print(f"\nExtracting audio for {self.audio_name}...\n")
-        clip.audio.write_audiofile(f"{self.audio_dir}/{self.audio_name}.mp3")
-        print("\nFinished extracting audio!\n")
+        try:
+            os.makedirs(self.audio_dir, exist_ok=True)
+            print(f"\nExtracting audio for {self.audio_name}...\n")
+            clip.audio.write_audiofile(f"{self.audio_dir}/{self.audio_name}.mp3")
+            print("\nFinished extracting audio!\n")
+        finally:
+            clip.close()
 
 
 if __name__ == "__main__":

--- a/src/audio_normalizer.py
+++ b/src/audio_normalizer.py
@@ -4,6 +4,7 @@ from pydub import AudioSegment
 
 from utils import get_file_strings
 from process_class import ProcessClass
+from constants import NORMALIZED_DIR
 
 
 class FileNotSupported(Exception):
@@ -13,17 +14,17 @@ class FileNotSupported(Exception):
 class AudioNormalizer(ProcessClass):
     """AudioNormalizer class to normalize audio of mp3 file."""
 
-    def __init__(self, audio_path: str, target_dbfs: int) -> None:
+    def __init__(self, audio_path: str, target_dbfs: float) -> None:
         """Init method for the `AudioNormalizer` class.
 
         Args:
             audio_path (str): Path to audio file.
-            target_dbfs (int): Decibels relative to full scale target value.
+            target_dbfs (float): Decibels relative to full scale target value.
         """
         self.audio_path = audio_path
         self.target_dbfs = target_dbfs
         self.audio_name, self.audio_ext = get_file_strings(self.audio_path)
-        self.normalized_dir = "./data/normalized_audio"
+        self.normalized_dir = str(NORMALIZED_DIR)
 
     def process_file(self):
         """Normalize audio of an mp3 file based on a target dBFS value.

--- a/src/audio_normalizer.py
+++ b/src/audio_normalizer.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+from pathlib import Path
 from pydub import AudioSegment
 
 from utils import get_file_strings
@@ -24,9 +25,9 @@ class AudioNormalizer(ProcessClass):
         self.audio_path = audio_path
         self.target_dbfs = target_dbfs
         self.audio_name, self.audio_ext = get_file_strings(self.audio_path)
-        self.normalized_dir = str(NORMALIZED_DIR)
+        self.normalized_dir: Path = NORMALIZED_DIR
 
-    def process_file(self):
+    def process_file(self) -> None:
         """Normalize audio of an mp3 file based on a target dBFS value.
 
         Raises:
@@ -42,7 +43,7 @@ class AudioNormalizer(ProcessClass):
         audio_diff = self.target_dbfs - sound.dBFS
         normalized_audio = sound.apply_gain(audio_diff)
         normalized_audio.export(
-            f"{self.normalized_dir}/{self.audio_name}_norm.{self.audio_ext}"
+            self.normalized_dir / f"{self.audio_name}_norm.{self.audio_ext}"
         )
 
 
@@ -52,7 +53,7 @@ if __name__ == "__main__":
         "--audio_path", type=str, default=None, help="Path to audio file to normalize."
     )
     parser.add_argument(
-        "--dBFS", type=int, default=-30, help="Target dBFS. Defaults to -30."
+        "--dBFS", type=float, default=-30, help="Target dBFS. Defaults to -30."
     )
     args = parser.parse_args()
     an = AudioNormalizer(args.audio_path, args.dBFS)

--- a/src/audio_tagger.py
+++ b/src/audio_tagger.py
@@ -56,6 +56,7 @@ class AudioTagger(ProcessClass):
         """
         print(f"Tagging {self.title_tag}...")
         self.get_mp3()
+        assert self.mp3_file is not None
         if self.mp3_file.tag is None:
             self.mp3_file.initTag()
         self.mp3_file.tag.album = self.album_tag

--- a/src/audio_tagger.py
+++ b/src/audio_tagger.py
@@ -1,6 +1,7 @@
 import argparse
 
 import eyed3
+import eyed3.id3
 
 from utils import get_file_strings
 from process_class import ProcessClass

--- a/src/audio_tagger.py
+++ b/src/audio_tagger.py
@@ -2,6 +2,7 @@ import argparse
 
 import eyed3
 import eyed3.id3
+import eyed3.mp3
 
 from utils import get_file_strings
 from process_class import ProcessClass
@@ -15,7 +16,7 @@ class AudioTagger(ProcessClass):
         sound_file_path: str,
         artist_tag: str,
         album_tag: str,
-        title_tag: str = None,
+        title_tag: str | None = None,
     ) -> None:
         """Init method for `AudioTagger` class.
 
@@ -23,7 +24,7 @@ class AudioTagger(ProcessClass):
             sound_file_path (str): Path to audio file.
             artist_tag (str): Artist name.
             album_tag (str): Album name.
-            title_tag (str, optional): Title of mp3.
+            title_tag (str | None, optional): Title of mp3.
                 If None, will use the name of the mp3 file.
                 Defaults to None.
         """
@@ -34,11 +35,20 @@ class AudioTagger(ProcessClass):
             self.title_tag, _ = get_file_strings(self.sound_file_path)
         else:
             self.title_tag = title_tag
-        self.mp3_file = None
+        self.mp3_file: eyed3.mp3.Mp3AudioFile | None = None
 
     def get_mp3(self) -> None:
-        """Loads a mp3 file as a eyed3.mp3.Mp3AudioFile object."""
+        """Loads a mp3 file as an eyed3.mp3.Mp3AudioFile object.
+
+        Raises:
+            ValueError: If the file cannot be loaded by eyed3.
+        """
         self.mp3_file = eyed3.load(self.sound_file_path)
+        if self.mp3_file is None:
+            raise ValueError(
+                f"Failed to load MP3 file: {self.sound_file_path!r}. "
+                "The file may be corrupt or is not a valid MP3."
+            )
 
     def process_file(self) -> None:
         """Loads mp3 file and tags it with album/artist/title tags.

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,5 @@
+"""Shared path constants and file extension sets for the audio-extractor pipeline."""
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -5,12 +7,5 @@ DATA_DIR = REPO_ROOT / "data"
 NORMALIZED_DIR = DATA_DIR / "normalized_audio"
 EXTRACTED_DIR = DATA_DIR / "extracted_audio"
 
-VID_EXTS = [
-    "mp4",
-    "avi",
-    "mov",
-    "mkv",
-]
-AUDIO_EXTS = [
-    "mp3",
-]
+VID_EXTS: frozenset[str] = frozenset({"mp4", "avi", "mov", "mkv"})
+AUDIO_EXTS: frozenset[str] = frozenset({"mp3"})

--- a/src/files_processor.py
+++ b/src/files_processor.py
@@ -1,6 +1,7 @@
 import os
 import argparse
-from typing import List, Callable
+from pathlib import Path
+from collections.abc import Callable, Collection
 from constants import VID_EXTS, AUDIO_EXTS, EXTRACTED_DIR, NORMALIZED_DIR
 from utils import is_valid_ext
 from audio_extractor import AudioExtractor
@@ -9,14 +10,14 @@ from audio_normalizer import AudioNormalizer
 
 
 def process_all_files(
-    file_dir: str, ext_list: List[str], process_class: Callable, **kwargs
+    file_dir: str | Path, ext_list: Collection[str], process_class: Callable, **kwargs
 ) -> None:
     """Process all files in specified directory. Will process
     files if they match an extension in the ext_list variable.
 
     Args:
-        file_dir (str): Directory containing files.
-        ext_list (List[str]): List of valid extensions to check against.
+        file_dir (str | Path): Directory containing files.
+        ext_list (Collection[str]): Collection of valid extensions to check against.
         process_class (Callable): Specific processing class to use.
     """
     file_names = os.listdir(file_dir)
@@ -57,7 +58,7 @@ if __name__ == "__main__":
         help="Tag flag - tag audio from files in directory.",
     )
     parser.add_argument(
-        "--dBFS", type=int, default=-30, help="Target dBFS. Defaults to -30."
+        "--dBFS", type=float, default=-30, help="Target dBFS. Defaults to -30."
     )
     parser.add_argument(
         "--artist",

--- a/src/normalize_audios_from_dir.py
+++ b/src/normalize_audios_from_dir.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         help="Directory containing audio files to normalize.",
     )
     parser.add_argument(
-        "--dBFS", type=int, default=-30, help="Target dBFS. Defaults to -30."
+        "--dBFS", type=float, default=-30, help="Target dBFS. Defaults to -30."
     )
     args = parser.parse_args()
     process_all_files(args.dir, AUDIO_EXTS, AudioNormalizer, target_dbfs=args.dBFS)

--- a/src/process_class.py
+++ b/src/process_class.py
@@ -5,7 +5,7 @@ class ProcessClass(abc.ABC):
     """Enforce the ProcessClasses to have a process_file method.
     """
     @abc.abstractmethod
-    def process_file(self):
+    def process_file(self) -> None:
         """Method called to process a file by a ProcessClass.
         """
         pass

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
-from typing import Tuple, List
+from collections.abc import Collection
 
 
-def get_file_strings(file_path: str, full_path=False) -> Tuple[str, str]:
+def get_file_strings(file_path: str, full_path: bool = False) -> tuple[str, str]:
     """Split file path name into name / file extension.
 
     Args:
@@ -11,7 +11,7 @@ def get_file_strings(file_path: str, full_path=False) -> Tuple[str, str]:
             Defaults to False.
 
     Returns:
-        Tuple[str, str]: File name string and image
+        tuple[str, str]: File name string and file
             extension string.
     """
 
@@ -24,11 +24,12 @@ def get_file_strings(file_path: str, full_path=False) -> Tuple[str, str]:
     return file_name, file_ext
 
 
-def is_valid_ext(file_path: str, ext_list: List[str]) -> bool:
+def is_valid_ext(file_path: str, ext_list: Collection[str]) -> bool:
     """Check if file has a valid extension.
 
     Args:
         file_path (str): File path (ex: mydir/my_file.txt)
+        ext_list (Collection[str]): Collection of valid extensions to check against.
 
     Returns:
         bool: Bool indicating if the file is a

--- a/tests/test_audio_extractor.py
+++ b/tests/test_audio_extractor.py
@@ -94,11 +94,12 @@ class TestAudioExtractorProcessFile:
         mock_clip.close.assert_called_once()
 
     def test_process_file_raises_when_no_audio_track(self, mock_clip_env):
-        mock_clip, _ = mock_clip_env
+        mock_clip, mock_makedirs = mock_clip_env
         mock_clip.audio = None
         ae = AudioExtractor("/some/path/my_video.mp4")
 
         with pytest.raises(ValueError, match="no audio track"):
             ae.process_file()
 
+        mock_makedirs.assert_not_called()
         mock_clip.close.assert_called_once()

--- a/tests/test_audio_extractor.py
+++ b/tests/test_audio_extractor.py
@@ -1,0 +1,112 @@
+import pytest
+from constants import EXTRACTED_DIR
+
+
+class TestAudioExtractorInit:
+    def test_raises_when_file_not_found(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=False)
+        from audio_extractor import AudioExtractor
+
+        with pytest.raises(AttributeError):
+            AudioExtractor("/nonexistent/path/video.mp4")
+
+    def test_defaults_audio_name_to_filename(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        assert ae.audio_name == "my_video"
+
+    def test_stores_custom_audio_name(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4", audio_name="custom_name")
+        assert ae.audio_name == "custom_name"
+
+    def test_audio_dir_uses_extracted_dir_constant(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        assert ae.audio_dir == str(EXTRACTED_DIR)
+
+
+class TestAudioExtractorGetClip:
+    def test_get_clip_calls_video_file_clip(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mock_vfc = mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        result = ae.get_clip()
+
+        mock_vfc.assert_called_once_with("/some/path/my_video.mp4")
+        assert result is mock_clip
+
+
+class TestAudioExtractorProcessFile:
+    def test_process_file_calls_makedirs_with_exist_ok(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        mock_makedirs = mocker.patch("audio_extractor.os.makedirs")
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        ae.process_file()
+
+        mock_makedirs.assert_called_once_with(ae.audio_dir, exist_ok=True)
+
+    def test_process_file_calls_write_audiofile_with_correct_path(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        mocker.patch("audio_extractor.os.makedirs")
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        ae.process_file()
+
+        expected_path = f"{ae.audio_dir}/my_video.mp3"
+        mock_clip.audio.write_audiofile.assert_called_once_with(expected_path)
+
+    def test_process_file_uses_custom_name_in_path(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        mocker.patch("audio_extractor.os.makedirs")
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4", audio_name="custom_name")
+        ae.process_file()
+
+        expected_path = f"{ae.audio_dir}/custom_name.mp3"
+        mock_clip.audio.write_audiofile.assert_called_once_with(expected_path)
+
+    def test_process_file_closes_clip_on_success(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        mocker.patch("audio_extractor.os.makedirs")
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        ae.process_file()
+
+        mock_clip.close.assert_called_once()
+
+    def test_process_file_closes_clip_on_error(self, mocker):
+        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+        mock_clip = mocker.MagicMock()
+        mock_clip.audio.write_audiofile.side_effect = RuntimeError("write failed")
+        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+        mocker.patch("audio_extractor.os.makedirs")
+        from audio_extractor import AudioExtractor
+
+        ae = AudioExtractor("/some/path/my_video.mp4")
+        with pytest.raises(RuntimeError):
+            ae.process_file()
+
+        mock_clip.close.assert_called_once()

--- a/tests/test_audio_extractor.py
+++ b/tests/test_audio_extractor.py
@@ -1,35 +1,42 @@
 import pytest
 from constants import EXTRACTED_DIR
+from audio_extractor import AudioExtractor
+
+
+@pytest.fixture
+def mock_clip_env(mocker):
+    """Patch isfile, VideoFileClip, and makedirs for AudioExtractor process_file tests."""
+    mocker.patch("audio_extractor.os.path.isfile", return_value=True)
+    mock_clip = mocker.MagicMock()
+    mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
+    mock_makedirs = mocker.patch("audio_extractor.os.makedirs")
+    return mock_clip, mock_makedirs
 
 
 class TestAudioExtractorInit:
     def test_raises_when_file_not_found(self, mocker):
         mocker.patch("audio_extractor.os.path.isfile", return_value=False)
-        from audio_extractor import AudioExtractor
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(FileNotFoundError):
             AudioExtractor("/nonexistent/path/video.mp4")
 
     def test_defaults_audio_name_to_filename(self, mocker):
         mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        from audio_extractor import AudioExtractor
 
         ae = AudioExtractor("/some/path/my_video.mp4")
         assert ae.audio_name == "my_video"
 
     def test_stores_custom_audio_name(self, mocker):
         mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        from audio_extractor import AudioExtractor
 
         ae = AudioExtractor("/some/path/my_video.mp4", audio_name="custom_name")
         assert ae.audio_name == "custom_name"
 
     def test_audio_dir_uses_extracted_dir_constant(self, mocker):
         mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        from audio_extractor import AudioExtractor
 
         ae = AudioExtractor("/some/path/my_video.mp4")
-        assert ae.audio_dir == str(EXTRACTED_DIR)
+        assert ae.audio_dir == EXTRACTED_DIR
 
 
 class TestAudioExtractorGetClip:
@@ -37,7 +44,6 @@ class TestAudioExtractorGetClip:
         mocker.patch("audio_extractor.os.path.isfile", return_value=True)
         mock_clip = mocker.MagicMock()
         mock_vfc = mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        from audio_extractor import AudioExtractor
 
         ae = AudioExtractor("/some/path/my_video.mp4")
         result = ae.get_clip()
@@ -47,66 +53,52 @@ class TestAudioExtractorGetClip:
 
 
 class TestAudioExtractorProcessFile:
-    def test_process_file_calls_makedirs_with_exist_ok(self, mocker):
-        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        mock_clip = mocker.MagicMock()
-        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        mock_makedirs = mocker.patch("audio_extractor.os.makedirs")
-        from audio_extractor import AudioExtractor
-
+    def test_process_file_calls_makedirs_with_exist_ok(self, mock_clip_env):
+        mock_clip, mock_makedirs = mock_clip_env
         ae = AudioExtractor("/some/path/my_video.mp4")
         ae.process_file()
 
         mock_makedirs.assert_called_once_with(ae.audio_dir, exist_ok=True)
 
-    def test_process_file_calls_write_audiofile_with_correct_path(self, mocker):
-        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        mock_clip = mocker.MagicMock()
-        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        mocker.patch("audio_extractor.os.makedirs")
-        from audio_extractor import AudioExtractor
-
+    def test_process_file_calls_write_audiofile_with_correct_path(self, mock_clip_env):
+        mock_clip, _ = mock_clip_env
         ae = AudioExtractor("/some/path/my_video.mp4")
         ae.process_file()
 
-        expected_path = f"{ae.audio_dir}/my_video.mp3"
+        expected_path = ae.audio_dir / "my_video.mp3"
         mock_clip.audio.write_audiofile.assert_called_once_with(expected_path)
 
-    def test_process_file_uses_custom_name_in_path(self, mocker):
-        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        mock_clip = mocker.MagicMock()
-        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        mocker.patch("audio_extractor.os.makedirs")
-        from audio_extractor import AudioExtractor
-
+    def test_process_file_uses_custom_name_in_path(self, mock_clip_env):
+        mock_clip, _ = mock_clip_env
         ae = AudioExtractor("/some/path/my_video.mp4", audio_name="custom_name")
         ae.process_file()
 
-        expected_path = f"{ae.audio_dir}/custom_name.mp3"
+        expected_path = ae.audio_dir / "custom_name.mp3"
         mock_clip.audio.write_audiofile.assert_called_once_with(expected_path)
 
-    def test_process_file_closes_clip_on_success(self, mocker):
-        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        mock_clip = mocker.MagicMock()
-        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        mocker.patch("audio_extractor.os.makedirs")
-        from audio_extractor import AudioExtractor
-
+    def test_process_file_closes_clip_on_success(self, mock_clip_env):
+        mock_clip, _ = mock_clip_env
         ae = AudioExtractor("/some/path/my_video.mp4")
         ae.process_file()
 
         mock_clip.close.assert_called_once()
 
-    def test_process_file_closes_clip_on_error(self, mocker):
-        mocker.patch("audio_extractor.os.path.isfile", return_value=True)
-        mock_clip = mocker.MagicMock()
+    def test_process_file_closes_clip_on_error(self, mock_clip_env):
+        mock_clip, _ = mock_clip_env
         mock_clip.audio.write_audiofile.side_effect = RuntimeError("write failed")
-        mocker.patch("audio_extractor.VideoFileClip", return_value=mock_clip)
-        mocker.patch("audio_extractor.os.makedirs")
-        from audio_extractor import AudioExtractor
-
         ae = AudioExtractor("/some/path/my_video.mp4")
+
         with pytest.raises(RuntimeError):
+            ae.process_file()
+
+        mock_clip.close.assert_called_once()
+
+    def test_process_file_raises_when_no_audio_track(self, mock_clip_env):
+        mock_clip, _ = mock_clip_env
+        mock_clip.audio = None
+        ae = AudioExtractor("/some/path/my_video.mp4")
+
+        with pytest.raises(ValueError, match="no audio track"):
             ae.process_file()
 
         mock_clip.close.assert_called_once()

--- a/tests/test_audio_normalizer.py
+++ b/tests/test_audio_normalizer.py
@@ -1,0 +1,102 @@
+import pytest
+from constants import NORMALIZED_DIR
+
+
+class TestAudioNormalizerInit:
+    def test_stores_audio_path(self):
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        assert an.audio_path == "/some/path/audio.mp3"
+
+    def test_stores_target_dbfs(self):
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        assert an.target_dbfs == -20.0
+
+    def test_parses_name(self):
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-30.0)
+        assert an.audio_name == "my_audio"
+
+    def test_parses_ext(self):
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-30.0)
+        assert an.audio_ext == "mp3"
+
+    def test_normalized_dir_uses_constant(self):
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        assert an.normalized_dir == str(NORMALIZED_DIR)
+
+
+class TestAudioNormalizerProcessFile:
+    def test_raises_file_not_supported_for_non_mp3(self, mocker):
+        from audio_normalizer import AudioNormalizer, FileNotSupported
+
+        an = AudioNormalizer("/some/path/audio.wav", target_dbfs=-20.0)
+        with pytest.raises(FileNotSupported):
+            an.process_file()
+
+    def test_creates_output_directory(self, mocker):
+        mock_makedirs = mocker.patch("audio_normalizer.os.makedirs")
+        mock_sound = mocker.MagicMock()
+        mock_sound.dBFS = -40.0
+        mocker.patch(
+            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
+        )
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        an.process_file()
+
+        mock_makedirs.assert_called_once_with(an.normalized_dir, exist_ok=True)
+
+    def test_computes_correct_gain_delta(self, mocker):
+        mocker.patch("audio_normalizer.os.makedirs")
+        mock_sound = mocker.MagicMock()
+        mock_sound.dBFS = -40.0
+        mocker.patch(
+            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
+        )
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        an.process_file()
+
+        mock_sound.apply_gain.assert_called_once_with(20.0)
+
+    def test_exports_to_correct_path(self, mocker):
+        mocker.patch("audio_normalizer.os.makedirs")
+        mock_sound = mocker.MagicMock()
+        mock_sound.dBFS = -40.0
+        mock_normalized = mocker.MagicMock()
+        mock_sound.apply_gain.return_value = mock_normalized
+        mocker.patch(
+            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
+        )
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-20.0)
+        an.process_file()
+
+        expected_path = f"{an.normalized_dir}/my_audio_norm.mp3"
+        mock_normalized.export.assert_called_once_with(expected_path)
+
+    def test_loads_from_correct_audio_path(self, mocker):
+        mocker.patch("audio_normalizer.os.makedirs")
+        mock_sound = mocker.MagicMock()
+        mock_sound.dBFS = -30.0
+        mock_from_mp3 = mocker.patch(
+            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
+        )
+        from audio_normalizer import AudioNormalizer
+
+        an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
+        an.process_file()
+
+        mock_from_mp3.assert_called_once_with("/some/path/audio.mp3")

--- a/tests/test_audio_normalizer.py
+++ b/tests/test_audio_normalizer.py
@@ -1,43 +1,32 @@
 import pytest
 from constants import NORMALIZED_DIR
+from audio_normalizer import AudioNormalizer, FileNotSupported
 
 
 class TestAudioNormalizerInit:
     def test_stores_audio_path(self):
-        from audio_normalizer import AudioNormalizer
-
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
         assert an.audio_path == "/some/path/audio.mp3"
 
     def test_stores_target_dbfs(self):
-        from audio_normalizer import AudioNormalizer
-
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
         assert an.target_dbfs == -20.0
 
     def test_parses_name(self):
-        from audio_normalizer import AudioNormalizer
-
         an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-30.0)
         assert an.audio_name == "my_audio"
 
     def test_parses_ext(self):
-        from audio_normalizer import AudioNormalizer
-
         an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-30.0)
         assert an.audio_ext == "mp3"
 
     def test_normalized_dir_uses_constant(self):
-        from audio_normalizer import AudioNormalizer
-
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
-        assert an.normalized_dir == str(NORMALIZED_DIR)
+        assert an.normalized_dir == NORMALIZED_DIR
 
 
 class TestAudioNormalizerProcessFile:
-    def test_raises_file_not_supported_for_non_mp3(self, mocker):
-        from audio_normalizer import AudioNormalizer, FileNotSupported
-
+    def test_raises_file_not_supported_for_non_mp3(self):
         an = AudioNormalizer("/some/path/audio.wav", target_dbfs=-20.0)
         with pytest.raises(FileNotSupported):
             an.process_file()
@@ -46,10 +35,7 @@ class TestAudioNormalizerProcessFile:
         mock_makedirs = mocker.patch("audio_normalizer.os.makedirs")
         mock_sound = mocker.MagicMock()
         mock_sound.dBFS = -40.0
-        mocker.patch(
-            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
-        )
-        from audio_normalizer import AudioNormalizer
+        mocker.patch("audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound)
 
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
         an.process_file()
@@ -60,10 +46,7 @@ class TestAudioNormalizerProcessFile:
         mocker.patch("audio_normalizer.os.makedirs")
         mock_sound = mocker.MagicMock()
         mock_sound.dBFS = -40.0
-        mocker.patch(
-            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
-        )
-        from audio_normalizer import AudioNormalizer
+        mocker.patch("audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound)
 
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
         an.process_file()
@@ -76,15 +59,12 @@ class TestAudioNormalizerProcessFile:
         mock_sound.dBFS = -40.0
         mock_normalized = mocker.MagicMock()
         mock_sound.apply_gain.return_value = mock_normalized
-        mocker.patch(
-            "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
-        )
-        from audio_normalizer import AudioNormalizer
+        mocker.patch("audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound)
 
         an = AudioNormalizer("/some/path/my_audio.mp3", target_dbfs=-20.0)
         an.process_file()
 
-        expected_path = f"{an.normalized_dir}/my_audio_norm.mp3"
+        expected_path = an.normalized_dir / "my_audio_norm.mp3"
         mock_normalized.export.assert_called_once_with(expected_path)
 
     def test_loads_from_correct_audio_path(self, mocker):
@@ -94,7 +74,6 @@ class TestAudioNormalizerProcessFile:
         mock_from_mp3 = mocker.patch(
             "audio_normalizer.AudioSegment.from_mp3", return_value=mock_sound
         )
-        from audio_normalizer import AudioNormalizer
 
         an = AudioNormalizer("/some/path/audio.mp3", target_dbfs=-20.0)
         an.process_file()

--- a/tests/test_audio_tagger.py
+++ b/tests/test_audio_tagger.py
@@ -1,0 +1,133 @@
+import pytest
+
+
+class TestAudioTaggerInit:
+    def test_stores_sound_file_path(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        assert at.sound_file_path == "/some/path/track.mp3"
+
+    def test_stores_artist_tag(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
+        assert at.artist_tag == "My Artist"
+
+    def test_stores_album_tag(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
+        assert at.album_tag == "My Album"
+
+    def test_defaults_title_to_filename(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/my_track.mp3", "Artist", "Album")
+        assert at.title_tag == "my_track"
+
+    def test_stores_custom_title_tag(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album", title_tag="Custom Title")
+        assert at.title_tag == "Custom Title"
+
+    def test_mp3_file_is_none_before_get_mp3(self):
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        assert at.mp3_file is None
+
+
+class TestAudioTaggerGetMp3:
+    def test_get_mp3_calls_eyed3_load(self, mocker):
+        mock_mp3 = mocker.MagicMock()
+        mock_load = mocker.patch("audio_tagger.eyed3.load", return_value=mock_mp3)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        at.get_mp3()
+
+        mock_load.assert_called_once_with("/some/path/track.mp3")
+        assert at.mp3_file is mock_mp3
+
+
+class TestAudioTaggerProcessFile:
+    def _make_mock_mp3(self, mocker, tag=None):
+        mock_mp3 = mocker.MagicMock()
+        mock_mp3.tag = tag if tag is not None else mocker.MagicMock()
+        mocker.patch("audio_tagger.eyed3.load", return_value=mock_mp3)
+        return mock_mp3
+
+    def test_process_file_calls_get_mp3(self, mocker):
+        self._make_mock_mp3(mocker)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        spy = mocker.spy(at, "get_mp3")
+        at.process_file()
+
+        spy.assert_called_once()
+
+    def test_process_file_sets_artist(self, mocker):
+        mock_mp3 = self._make_mock_mp3(mocker)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
+        at.process_file()
+
+        assert mock_mp3.tag.artist == "My Artist"
+
+    def test_process_file_sets_album(self, mocker):
+        mock_mp3 = self._make_mock_mp3(mocker)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
+        at.process_file()
+
+        assert mock_mp3.tag.album == "My Album"
+
+    def test_process_file_sets_title(self, mocker):
+        mock_mp3 = self._make_mock_mp3(mocker)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album", title_tag="My Title")
+        at.process_file()
+
+        assert mock_mp3.tag.title == "My Title"
+
+    def test_process_file_calls_init_tag_when_tag_is_none(self, mocker):
+        mock_mp3 = mocker.MagicMock()
+        mock_tag = mocker.MagicMock()
+        mock_mp3.tag = None
+
+        def init_tag_side_effect():
+            mock_mp3.tag = mock_tag
+
+        mock_mp3.initTag.side_effect = init_tag_side_effect
+        mocker.patch("audio_tagger.eyed3.load", return_value=mock_mp3)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        at.process_file()
+
+        mock_mp3.initTag.assert_called_once()
+
+    def test_process_file_skips_init_tag_when_tag_exists(self, mocker):
+        mock_mp3 = self._make_mock_mp3(mocker)
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        at.process_file()
+
+        mock_mp3.initTag.assert_not_called()
+
+    def test_process_file_saves_with_id3_v2_3(self, mocker):
+        mock_mp3 = self._make_mock_mp3(mocker)
+        import eyed3
+        from audio_tagger import AudioTagger
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        at.process_file()
+
+        mock_mp3.tag.save.assert_called_once_with(version=eyed3.id3.ID3_V2_3)

--- a/tests/test_audio_tagger.py
+++ b/tests/test_audio_tagger.py
@@ -1,40 +1,31 @@
 import pytest
+import eyed3
+import eyed3.id3
+from audio_tagger import AudioTagger
 
 
 class TestAudioTaggerInit:
     def test_stores_sound_file_path(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         assert at.sound_file_path == "/some/path/track.mp3"
 
     def test_stores_artist_tag(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
         assert at.artist_tag == "My Artist"
 
     def test_stores_album_tag(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
         assert at.album_tag == "My Album"
 
     def test_defaults_title_to_filename(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/my_track.mp3", "Artist", "Album")
         assert at.title_tag == "my_track"
 
     def test_stores_custom_title_tag(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album", title_tag="Custom Title")
         assert at.title_tag == "Custom Title"
 
     def test_mp3_file_is_none_before_get_mp3(self):
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         assert at.mp3_file is None
 
@@ -43,13 +34,19 @@ class TestAudioTaggerGetMp3:
     def test_get_mp3_calls_eyed3_load(self, mocker):
         mock_mp3 = mocker.MagicMock()
         mock_load = mocker.patch("audio_tagger.eyed3.load", return_value=mock_mp3)
-        from audio_tagger import AudioTagger
 
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         at.get_mp3()
 
         mock_load.assert_called_once_with("/some/path/track.mp3")
         assert at.mp3_file is mock_mp3
+
+    def test_get_mp3_raises_when_eyed3_returns_none(self, mocker):
+        mocker.patch("audio_tagger.eyed3.load", return_value=None)
+
+        at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
+        with pytest.raises(ValueError, match="Failed to load"):
+            at.get_mp3()
 
 
 class TestAudioTaggerProcessFile:
@@ -61,8 +58,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_calls_get_mp3(self, mocker):
         self._make_mock_mp3(mocker)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         spy = mocker.spy(at, "get_mp3")
         at.process_file()
@@ -71,8 +66,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_sets_artist(self, mocker):
         mock_mp3 = self._make_mock_mp3(mocker)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
         at.process_file()
 
@@ -80,8 +73,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_sets_album(self, mocker):
         mock_mp3 = self._make_mock_mp3(mocker)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "My Artist", "My Album")
         at.process_file()
 
@@ -89,8 +80,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_sets_title(self, mocker):
         mock_mp3 = self._make_mock_mp3(mocker)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album", title_tag="My Title")
         at.process_file()
 
@@ -106,8 +95,6 @@ class TestAudioTaggerProcessFile:
 
         mock_mp3.initTag.side_effect = init_tag_side_effect
         mocker.patch("audio_tagger.eyed3.load", return_value=mock_mp3)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         at.process_file()
 
@@ -115,8 +102,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_skips_init_tag_when_tag_exists(self, mocker):
         mock_mp3 = self._make_mock_mp3(mocker)
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         at.process_file()
 
@@ -124,9 +109,6 @@ class TestAudioTaggerProcessFile:
 
     def test_process_file_saves_with_id3_v2_3(self, mocker):
         mock_mp3 = self._make_mock_mp3(mocker)
-        import eyed3
-        from audio_tagger import AudioTagger
-
         at = AudioTagger("/some/path/track.mp3", "Artist", "Album")
         at.process_file()
 

--- a/tests/test_files_processor.py
+++ b/tests/test_files_processor.py
@@ -1,5 +1,5 @@
-import pytest
 import os
+from files_processor import process_all_files
 
 
 class TestProcessAllFiles:
@@ -7,7 +7,6 @@ class TestProcessAllFiles:
         mocker.patch("files_processor.os.listdir", return_value=["a.mp4", "b.mp4"])
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 
@@ -19,7 +18,6 @@ class TestProcessAllFiles:
         )
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 
@@ -35,7 +33,6 @@ class TestProcessAllFiles:
 
         mocker.patch("files_processor.os.path.isfile", side_effect=isfile_side_effect)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 
@@ -45,7 +42,6 @@ class TestProcessAllFiles:
         mocker.patch("files_processor.os.listdir", return_value=["video.mp4"])
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 
@@ -56,11 +52,8 @@ class TestProcessAllFiles:
         mocker.patch("files_processor.os.listdir", return_value=["audio.mp3"])
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
-        process_all_files(
-            "/some/dir", ["mp3"], mock_process_class, target_dbfs=-20
-        )
+        process_all_files("/some/dir", ["mp3"], mock_process_class, target_dbfs=-20)
 
         expected_path = os.path.join("/some/dir", "audio.mp3")
         mock_process_class.assert_called_once_with(expected_path, target_dbfs=-20)
@@ -69,7 +62,6 @@ class TestProcessAllFiles:
         mocker.patch("files_processor.os.listdir", return_value=[])
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 
@@ -81,7 +73,6 @@ class TestProcessAllFiles:
         )
         mocker.patch("files_processor.os.path.isfile", return_value=True)
         mock_process_class = mocker.MagicMock()
-        from files_processor import process_all_files
 
         process_all_files("/some/dir", ["mp4"], mock_process_class)
 

--- a/tests/test_files_processor.py
+++ b/tests/test_files_processor.py
@@ -1,0 +1,88 @@
+import pytest
+import os
+
+
+class TestProcessAllFiles:
+    def test_calls_process_class_for_each_valid_file(self, mocker):
+        mocker.patch("files_processor.os.listdir", return_value=["a.mp4", "b.mp4"])
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        assert mock_process_class.call_count == 2
+
+    def test_skips_invalid_extensions(self, mocker):
+        mocker.patch(
+            "files_processor.os.listdir", return_value=["a.mp4", "b.txt", "c.mp4"]
+        )
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        assert mock_process_class.call_count == 2
+
+    def test_skips_non_file_entries(self, mocker):
+        mocker.patch(
+            "files_processor.os.listdir", return_value=["subdir", "video.mp4"]
+        )
+
+        def isfile_side_effect(path):
+            return not path.endswith("subdir")
+
+        mocker.patch("files_processor.os.path.isfile", side_effect=isfile_side_effect)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        assert mock_process_class.call_count == 1
+
+    def test_passes_correct_file_path(self, mocker):
+        mocker.patch("files_processor.os.listdir", return_value=["video.mp4"])
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        expected_path = os.path.join("/some/dir", "video.mp4")
+        mock_process_class.assert_called_once_with(expected_path)
+
+    def test_passes_kwargs_to_process_class(self, mocker):
+        mocker.patch("files_processor.os.listdir", return_value=["audio.mp3"])
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files(
+            "/some/dir", ["mp3"], mock_process_class, target_dbfs=-20
+        )
+
+        expected_path = os.path.join("/some/dir", "audio.mp3")
+        mock_process_class.assert_called_once_with(expected_path, target_dbfs=-20)
+
+    def test_handles_empty_directory(self, mocker):
+        mocker.patch("files_processor.os.listdir", return_value=[])
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        mock_process_class.assert_not_called()
+
+    def test_handles_dir_with_no_valid_extensions(self, mocker):
+        mocker.patch(
+            "files_processor.os.listdir", return_value=["doc.pdf", "image.jpg"]
+        )
+        mocker.patch("files_processor.os.path.isfile", return_value=True)
+        mock_process_class = mocker.MagicMock()
+        from files_processor import process_all_files
+
+        process_all_files("/some/dir", ["mp4"], mock_process_class)
+
+        mock_process_class.assert_not_called()

--- a/tests/test_process_class.py
+++ b/tests/test_process_class.py
@@ -1,0 +1,23 @@
+import pytest
+from process_class import ProcessClass
+
+
+class TestProcessClass:
+    def test_cannot_instantiate_abstract_class(self):
+        with pytest.raises(TypeError):
+            ProcessClass()
+
+    def test_concrete_subclass_without_process_file_raises(self):
+        class Incomplete(ProcessClass):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_concrete_subclass_implementing_process_file_works(self):
+        class Concrete(ProcessClass):
+            def process_file(self):
+                return "processed"
+
+        obj = Concrete()
+        assert obj.process_file() == "processed"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,60 @@
+import pytest
+from utils import get_file_strings, is_valid_ext
+from constants import VID_EXTS
+
+
+class TestGetFileStrings:
+    def test_simple_filename(self):
+        name, ext = get_file_strings("video.mp4")
+        assert name == "video"
+        assert ext == "mp4"
+
+    def test_path_stripping(self):
+        name, ext = get_file_strings("/some/path/to/video.avi")
+        assert name == "video"
+        assert ext == "avi"
+
+    def test_windows_backslash(self):
+        name, ext = get_file_strings("C:\\Users\\user\\video.mkv")
+        assert name == "video"
+        assert ext == "mkv"
+
+    def test_full_path_true(self):
+        name, ext = get_file_strings("/some/path/to/video.mp4", full_path=True)
+        assert name == "/some/path/to/video"
+        assert ext == "mp4"
+
+    def test_multiple_dots(self):
+        name, ext = get_file_strings("my.video.file.mp4")
+        assert name == "my.video.file"
+        assert ext == "mp4"
+
+    def test_audio_ext(self):
+        name, ext = get_file_strings("audio_track.mp3")
+        assert name == "audio_track"
+        assert ext == "mp3"
+
+    def test_path_with_directory(self):
+        name, ext = get_file_strings("data/extracted_audio/clip.mp3")
+        assert name == "clip"
+        assert ext == "mp3"
+
+
+class TestIsValidExt:
+    def test_valid_ext(self):
+        assert is_valid_ext("video.mp4", ["mp4", "avi"]) is True
+
+    def test_invalid_ext(self):
+        assert is_valid_ext("video.txt", ["mp4", "avi"]) is False
+
+    def test_case_sensitivity(self):
+        assert is_valid_ext("video.MP4", ["mp4", "avi"]) is False
+
+    def test_empty_list(self):
+        assert is_valid_ext("video.mp4", []) is False
+
+    def test_vid_exts_integration(self):
+        assert is_valid_ext("clip.mov", VID_EXTS) is True
+
+    def test_vid_exts_invalid(self):
+        assert is_valid_ext("clip.mp3", VID_EXTS) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import pytest
 from utils import get_file_strings, is_valid_ext
 from constants import VID_EXTS
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -24,7 +25,7 @@ dev = [
 requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.2" },
     { name = "eyed3", specifier = ">=0.9.8" },
-    { name = "moviepy", specifier = "==1.0.3" },
+    { name = "moviepy", specifier = ">=2.0.0" },
     { name = "pydub", specifier = ">=0.25.1" },
 ]
 
@@ -32,6 +33,7 @@ requires-dist = [
 dev = [
     { name = "pyright", specifier = ">=1.1.404" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.12.10" },
 ]
 
@@ -92,46 +94,6 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2025.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
-    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
-    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
-    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
-    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
-    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -184,15 +146,6 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
 name = "imageio"
 version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -230,18 +183,21 @@ wheels = [
 
 [[package]]
 name = "moviepy"
-version = "1.0.3"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decorator" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "numpy" },
+    { name = "pillow" },
     { name = "proglog" },
-    { name = "requests" },
-    { name = "tqdm" },
+    { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/54/01a8c4e35c75ca9724d19a7e4de9dc23f0ceb8769102c7de056113af61c3/moviepy-1.0.3.tar.gz", hash = "sha256:2884e35d1788077db3ff89e763c5ba7bfddbd7ae9108c9bc809e7ba58fa433f5", size = 388311, upload-time = "2020-05-07T16:27:46.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/61/15f9476e270f64c78a834e7459ca045d669f869cec24eed26807b8cd479d/moviepy-2.2.1.tar.gz", hash = "sha256:c80cb56815ece94e5e3e2d361aa40070eeb30a09d23a24c4e684d03e16deacb1", size = 58431438, upload-time = "2025-05-21T19:31:52.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl", hash = "sha256:6b56803fec2ac54b557404126ac1160e65448e03798fa282bd23e8fab3795060", size = 129871, upload-time = "2025-05-21T19:31:50.11Z" },
+]
 
 [[package]]
 name = "nodeenv"
@@ -437,18 +393,24 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.5"
+name = "pytest-mock"
+version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
 ]
 
 [[package]]
@@ -496,13 +458,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]


### PR DESCRIPTION
## Summary

- Add a 59-test pytest suite covering all source modules (utils, process_class, audio_extractor, audio_normalizer, audio_tagger, files_processor)
- Upgrade moviepy from pinned `1.0.3` to `>=2.0.0` and update import from `moviepy.editor` to `moviepy`
- Fix hard-coded relative paths (`./data/...`) in `AudioExtractor` and `AudioNormalizer` to use `EXTRACTED_DIR`/`NORMALIZED_DIR` constants
- Fix critical runtime bugs: unguarded `eyed3.load()` → `None`, unguarded `clip.audio` → `None`, wrong exception type (`AttributeError` → `FileNotFoundError`)
- Modernise type annotations: `str | None`, built-in generics, `Collection`, `frozenset`, `Path`
- Fix `--dBFS` CLI argument type from `int` to `float` across all three scripts
- Fix README typos (`ffmepg` → `ffmpeg`, `--dFBS` → `--dBFS`)

## Test plan

- [x] `uv sync` installs cleanly (moviepy 2.x, pytest-mock)
- [x] `uv run pytest -v` — all 59 tests pass, 0 failures
- [x] Manually run `uv run src/audio_extractor.py --vid_path <file>` from a directory other than the repo root to verify path fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)